### PR TITLE
Catch useless `?? null` and `?? undefined`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- `noUnnecessaryCondition`: Catch useless `?? null` and `?? undefined` coalescing and add "Remove unnecessary nullish coalescing" suggestion.
+
 ## 1.0.27
 
 - `preferOptionalChain`: fix chain analysis when the chain ends with `=== null`


### PR DESCRIPTION
Implements https://github.com/typescript-eslint/typescript-eslint/issues/8079 that I just had today