### PR TITLE
Project-wide rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ export default defineConfig({
 
 `enableProjectWideRulesInIDE` is an experimental new option to enable project-wide reports in the IDE (default to false). The IDE implementation is still a work in progress, and memory leaks or performance issues may occur.
 
+`core/unusedExport` is a new project-wide rule available with this release.
+
 ### Deprecate `context.rawChecker`
 
 Types overrides of `context.checker` have been updated so it can be passed to other libraries. `context.rawChecker` is therefore not needed anymore and has been deprecated. Thanks @JoshuaKGoldberg for challenging this!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,52 @@
 # Changelog
 
-## Unreleased
+## 1.1.0
 
-- Deprecate `context.rawChecker`. Types overrides from `context.checker` have been updated so it can be passed to other libraries. Thanks @JoshuaKGoldberg for challenging this!
+### Project-wide rules (experimental)
+
+Rules can now implement an `aggregate` function that will be called once for all files that have been linted. This allows to implement rules that require cross-file analysis, like detecting circular dependencies.
+
+```ts
+import { type AST, core, defineConfig } from "tsl";
+
+type ImportsData = {
+  imports: { path: string; node: AST.ImportDeclaration }[];
+};
+
+export default defineConfig({
+  rules: [
+    ...core.all(),
+    {
+      name: "org/noCircularDependencies",
+      createData: (): ImportsData => ({ imports: [] }),
+      visitor: {
+        ImportDeclaration(context, node) {
+          context.data.imports.push({ path: toAbsolutePath(node), node });
+        },
+      },
+      aggregate(context, files) {
+        //                ^ { sourceFile: AST.SourceFile; data: ImportsData }[]
+        for (const circularEntry of getCircularDependencies(files)) {
+          context.report({
+            message: "Circular dependency detected",
+            sourceFile: circularEntry.sourceFile,
+            node: circularEntry.data.imports[circularEntry.importIndex].node,
+          });
+        }
+      },
+    },
+  ],
+});
+```
+
+`enableProjectWideRulesInIDE` is an experimental new option to enable project-wide reports in the IDE (default to false). The IDE implementation is still a work in progress, and memory leaks or performance issues may occur.
+
+### Deprecate `context.rawChecker`
+
+Types overrides of `context.checker` have been updated so it can be passed to other libraries. `context.rawChecker` is therefore not needed anymore and has been deprecated. Thanks @JoshuaKGoldberg for challenging this!
+
+### Other
+
 - Port fixes from typescript-eslint up to v8.54.0
 
 ## 1.0.28

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ tsl is an extension of tsc for type-aware linting. It's designed to be used in c
 
 - Run type-aware rules [faster](https://github.com/ArnaudBarre/tsl/issues/3) than [typescript-eslint](https://typescript-eslint.io/)
 - Type safe config with custom rules in TypeScript
+- Project-wide rules (experimental)
 - No [IDE caching issue](https://typescript-eslint.io/troubleshooting/faqs/general/#changes-to-one-file-are-not-reflected-when-linting-other-files-in-my-ide)
 - Something missing? Look at the [roadmap](https://github.com/ArnaudBarre/tsl/issues/4) or [open an issue](https://github.com/ArnaudBarre/tsl/issues/new)
 
@@ -200,6 +201,10 @@ Like the ignore option, the `files` option test for inclusion against the file p
 
 Redeclared rules (identical name) completely replace the "base" rule, there is no merging of options.
 
+### enableProjectWideRulesInIDE (experimental)
+
+Enable project-wide rules in IDE. The IDE implementation is still a work in progress, and memory leaks or performance issues may occur. Enable and report issues if you encounter any.
+
 ## Ignore comments
 
 Rules reports can be ignored with line comments (ignore next line) or one line block comments (ignore for the whole file).
@@ -270,6 +275,49 @@ export default defineConfig({
   ],
 });
 ```
+
+### Project-wide rules (added in 1.1.0, experimental)
+
+Rules can optionally implement an `aggregate` function that will be called once for all files that have been linted. This allows to implement rules that require cross-file analysis, like detecting circular dependencies.
+
+```ts
+import { type AST, core, defineConfig } from "tsl";
+
+type ImportsData = {
+  imports: { path: string; node: AST.ImportDeclaration }[];
+};
+
+export default defineConfig({
+  rules: [
+    ...core.all(),
+    {
+      name: "org/noCircularDependencies",
+      createData: (): ImportsData => ({ imports: [] }),
+      visitor: {
+        ImportDeclaration(context, node) {
+          context.data.imports.push({ path: toAbsolutePath(node), node });
+        },
+      },
+      aggregate(context, files) {
+        //                ^ { sourceFile: AST.SourceFile; data: ImportsData }[]
+        for (const circularEntry of getCircularDependencies(files)) {
+          context.report({
+            message: "Circular dependency detected",
+            sourceFile: circularEntry.sourceFile,
+            node: circularEntry.data.imports[circularEntry.importIndex].node,
+          });
+        }
+      },
+    },
+  ],
+});
+```
+
+> [!CAUTION]
+> Project-wide rules are currently not supported inside overrides
+
+> [!IMPORTANT]
+> The list of files is only files that were linted. If you need a generated file to be in that list, but you still want to ignore all lint rules inside it, use a top level ignore comment instead of using the ignore option.
 
 ## Core rules
 

--- a/README.md
+++ b/README.md
@@ -321,7 +321,13 @@ export default defineConfig({
 
 ## Core rules
 
-Currently, the list of core rules are the type-aware lint rules I use from typescript-eslint. If you think more rules should be added, please open an issue, but to reduce the surface, only non-styling type-aware rules will be accepted. Here is the list of [typescript-eslint type aware rules](https://typescript-eslint.io/rules/?=typeInformation) with their status:
+### Exclusive rules
+
+- unusedExport: Detect unused exports (Using experimental project-wide linting)
+
+### From typescript-eslint
+
+Currently, the ported rules are the type-aware lint rules I use from typescript-eslint. If you think more rules should be added, please open an issue, but to reduce the surface, only non-styling type-aware rules will be accepted. Here is the list of [typescript-eslint type aware rules](https://typescript-eslint.io/rules/?=typeInformation) with their status:
 
 - await-thenable: ✅ Implemented
 - consistent-return: 🛑 Implementation not planned, you can use `noImplicitReturns` compilerOption

--- a/src/formatDiagnostic.ts
+++ b/src/formatDiagnostic.ts
@@ -179,7 +179,7 @@ function formatCodeSpan(
   return context;
 }
 
-export function formatLocation(file: SourceFile, start: number): string {
+function formatLocation(file: SourceFile, start: number): string {
   const { line, character } = getLineAndCharacterOfPosition(file, start);
   const relativeFileName = displayFilename(file.fileName);
   let output = "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import { restrictTemplateExpressions } from "./rules/restrictTemplateExpressions
 import { returnAwait } from "./rules/returnAwait/returnAwait.ts";
 import { strictBooleanExpressions } from "./rules/strictBooleanExpressions/strictBooleanExpressions.ts";
 import { switchExhaustivenessCheck } from "./rules/switchExhaustivenessCheck/switchExhaustivenessCheck.ts";
+import { unusedExport } from "./rules/unusedExport/unusedExport.ts";
 import type { Config, Rule } from "./types.ts";
 
 export type {
@@ -96,4 +97,5 @@ export const core = createRulesSet({
   returnAwait,
   strictBooleanExpressions,
   switchExhaustivenessCheck,
+  unusedExport,
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import { switchExhaustivenessCheck } from "./rules/switchExhaustivenessCheck/swi
 import { unusedExport } from "./rules/unusedExport/unusedExport.ts";
 import type { Config, Rule } from "./types.ts";
 
+/* tsl-ignore core/unusedExport */
 export type {
   AST,
   Checker,

--- a/src/loadConfig.ts
+++ b/src/loadConfig.ts
@@ -74,7 +74,7 @@ export const loadConfig = async (
   };
 };
 
-export const findConfigPath = (program: ts.Program) => {
+const findConfigPath = (program: ts.Program) => {
   let dir = program.getCurrentDirectory();
   const { root } = path.parse(dir);
   let configPath: string | undefined = undefined;

--- a/src/ruleTester.ts
+++ b/src/ruleTester.ts
@@ -4,6 +4,7 @@ import { getContextUtils } from "./getContextUtils.ts";
 import type { AST, Checker, Context, ReportDescriptor, Rule } from "./types.ts";
 import { visitorEntries } from "./visitorEntries.ts";
 
+// tsl-ignore core/unusedExport
 export function print(...args: any[]) {
   console.log(...args.map((value) => transform(value, new Set())));
 }

--- a/src/rules/_utils/getOperatorPrecedence.ts
+++ b/src/rules/_utils/getOperatorPrecedence.ts
@@ -392,7 +392,7 @@ export function getOperatorPrecedence(
   }
 }
 
-export function getBinaryOperatorPrecedence(kind: SyntaxKind): number {
+function getBinaryOperatorPrecedence(kind: SyntaxKind): number {
   switch (kind) {
     case SyntaxKind.MinusToken:
     case SyntaxKind.PlusToken:

--- a/src/rules/noMisusedPromises/noMisusedPromises.ts
+++ b/src/rules/noMisusedPromises/noMisusedPromises.ts
@@ -312,7 +312,7 @@ function checkVariableDeclaration(
   }
 }
 
-export function checkPropertyAssignment(
+function checkPropertyAssignment(
   context: Context<Data>,
   node: AST.PropertyAssignment,
 ) {
@@ -335,7 +335,7 @@ export function checkPropertyAssignment(
   }
 }
 
-export function checkShorthandPropertyAssignment(
+function checkShorthandPropertyAssignment(
   context: Context<Data>,
   node: AST.ShorthandPropertyAssignment,
 ) {
@@ -349,7 +349,7 @@ export function checkShorthandPropertyAssignment(
   }
 }
 
-export function checkMethodDeclaration(
+function checkMethodDeclaration(
   context: Context<Data>,
   node: AST.MethodDeclaration,
 ) {

--- a/src/rules/noUnnecessaryCondition/noUnnecessaryCondition.ts
+++ b/src/rules/noUnnecessaryCondition/noUnnecessaryCondition.ts
@@ -618,7 +618,7 @@ function checkCallExpression(
  * Inspect a call expression to see if it's a call to an assertion function.
  * If it is, return the node of the argument that is asserted and other useful info.
  */
-export function findTypeGuardAssertedArgument(
+function findTypeGuardAssertedArgument(
   context: Context,
   node: AST.CallExpression,
 ): { argument: AST.Expression; asserts: boolean; type: ts.Type } | undefined {
@@ -870,7 +870,7 @@ function checkOptionalChain(
 }
 
 // Truthiness utilities
-export function isPossiblyFalsy(type: ts.Type): boolean {
+function isPossiblyFalsy(type: ts.Type): boolean {
   return isTypeRecurser(type, (t) => {
     return t.isLiteral()
       ? !Boolean(getValueOfLiteralType(t))

--- a/src/rules/unusedExport/unusedExport.test.ts
+++ b/src/rules/unusedExport/unusedExport.test.ts
@@ -1,0 +1,113 @@
+import { expect, test } from "bun:test";
+import { ruleTester, type ValidTestCase } from "../../ruleTester.ts";
+import { messages, unusedExport } from "./unusedExport.ts";
+
+test("unusedExport", () => {
+  const hasError = ruleTester({
+    ruleFn: unusedExport,
+    valid: [
+      ...[
+        "export const foo = 1;",
+        "export const foo = () => 1;",
+        "const foo = 1; export { foo };",
+        "export function foo() { return 1; }",
+        "export class foo { }",
+      ].map(
+        (code): ValidTestCase<typeof unusedExport> => ({
+          files: [
+            { fileName: "file.ts", code },
+            { fileName: "file2.ts", code: `import { foo } from "./file.ts";` },
+          ],
+        }),
+      ),
+      ...[
+        "const foo = 1; export default foo;",
+        "export default function foo() { return 1; }",
+        "export default class foo { }",
+      ].map(
+        (code): ValidTestCase<typeof unusedExport> => ({
+          files: [
+            { fileName: "file.ts", code },
+            { fileName: "file2.ts", code: `import bar from "./file.ts";` },
+          ],
+        }),
+      ),
+      {
+        files: [
+          {
+            fileName: "file.ts",
+            code: "export const foo = 1; export const bar = 2;",
+          },
+          { fileName: "file2.ts", code: `import * as utils from "./file.ts";` },
+        ],
+      },
+    ],
+    invalid: [
+      {
+        files: [
+          {
+            fileName: "file.ts",
+            code: `export const foo = 1;\nexport const bar = 2;`,
+          },
+          { fileName: "file2.ts", code: `import { foo } from "./file.ts";` },
+        ],
+        errors: [
+          {
+            fileName: "file.ts",
+            message: messages.unusedNamedExport,
+            line: 2,
+          },
+        ],
+      },
+      {
+        files: [
+          {
+            fileName: "file.ts",
+            code: `export const foo = 1;\nconst bar = 2; export default bar;`,
+          },
+          { fileName: "file2.ts", code: `import { foo } from "./file.ts";` },
+        ],
+        errors: [
+          {
+            fileName: "file.ts",
+            message: messages.unusedDefaultExport,
+            line: 2,
+          },
+        ],
+      },
+      {
+        files: [
+          {
+            fileName: "file.ts",
+            code: `export const foo = 1;\nconst bar = 2; export { bar };`,
+          },
+          { fileName: "file2.ts", code: `import { foo } from "./file.ts";` },
+        ],
+        errors: [
+          {
+            fileName: "file.ts",
+            message: messages.unusedNamedExport,
+            line: 2,
+          },
+        ],
+      },
+      {
+        files: [
+          {
+            fileName: "file.ts",
+            code: `export const foo = 1;\nexport function bar() { return 2; };`,
+          },
+          { fileName: "file2.ts", code: `import { foo } from "./file.ts";` },
+        ],
+        errors: [
+          {
+            fileName: "file.ts",
+            message: messages.unusedNamedExport,
+            line: 2,
+          },
+        ],
+      },
+    ],
+  });
+  expect(hasError).toEqual(false);
+});

--- a/src/rules/unusedExport/unusedExport.ts
+++ b/src/rules/unusedExport/unusedExport.ts
@@ -1,0 +1,146 @@
+import { dirname, join } from "node:path";
+import ts, { SyntaxKind } from "typescript";
+import { defineRule, hasModifier } from "../_utils/index.ts";
+
+export const messages = {
+  unusedDefaultExport:
+    "This default export is never used. 'export default' can be removed.",
+  unusedNamedExport:
+    "This named export is never used. The export keyword can be removed.",
+};
+
+type ImportUsage = { named: string[]; default: boolean; star: boolean };
+type Data = {
+  path: string;
+  imports: Record<string, ImportUsage>;
+  exports: {
+    named: { name: string; node: ts.Node }[];
+    default: { node: ts.Node } | { start: number; end: number } | undefined;
+  };
+  usages: ImportUsage[];
+};
+
+export const unusedExport = defineRule(() => ({
+  name: "core/unusedExport",
+  createData: (context): Data => ({
+    path: context.sourceFile.fileName,
+    imports: {},
+    exports: { named: [], default: undefined },
+    usages: [],
+  }),
+  visitor: {
+    SourceFile(context) {
+      for (const el of context.sourceFile.statements) {
+        switch (el.kind) {
+          case SyntaxKind.ExportDeclaration:
+            if (el.exportClause?.kind === SyntaxKind.NamedExports) {
+              for (const e of el.exportClause.elements) {
+                context.data.exports.named.push({
+                  name: e.name.text,
+                  node: e.name,
+                });
+              }
+            }
+            break;
+          case SyntaxKind.ExportAssignment:
+            context.data.exports.default = {
+              start: el.getStart(),
+              end: el.expression.getStart() - 1,
+            };
+            break;
+          case SyntaxKind.VariableStatement:
+            if (hasModifier(el, SyntaxKind.ExportKeyword)) {
+              for (const v of el.declarationList.declarations) {
+                if (v.name.kind !== SyntaxKind.Identifier) continue; // Should not be possible
+                context.data.exports.named.push({
+                  name: v.name.text,
+                  node: v.name,
+                });
+              }
+            }
+            break;
+          case SyntaxKind.FunctionDeclaration:
+          case SyntaxKind.ClassDeclaration:
+            if (hasModifier(el, SyntaxKind.ExportKeyword)) {
+              const defaultModifier = el.modifiers?.find(
+                (m) => m.kind === SyntaxKind.DefaultKeyword,
+              );
+              if (defaultModifier) {
+                context.data.exports.default = { node: defaultModifier };
+              } else {
+                if (el.name) {
+                  context.data.exports.named.push({
+                    name: el.name.text,
+                    node: el.name,
+                  });
+                }
+              }
+            }
+            break;
+          default:
+            break;
+        }
+      }
+    },
+    ImportDeclaration(context, node) {
+      if (node.moduleSpecifier.kind !== SyntaxKind.StringLiteral) return;
+      const path = node.moduleSpecifier.text;
+      if (!path.startsWith(".")) return;
+      if (!path.endsWith(".ts") && !path.endsWith(".tsx")) return;
+      if (!node.importClause) return;
+      const fullPath = join(dirname(context.sourceFile.fileName), path);
+      context.data.imports[fullPath] ??= {
+        named: [],
+        default: false,
+        star: false,
+      };
+      if (node.importClause.name) {
+        context.data.imports[fullPath].default = true;
+      }
+      if (node.importClause.namedBindings?.kind === SyntaxKind.NamedImports) {
+        for (const el of node.importClause.namedBindings.elements) {
+          context.data.imports[fullPath].named.push(el.name.text);
+        }
+      }
+      if (
+        node.importClause.namedBindings?.kind === SyntaxKind.NamespaceImport
+      ) {
+        context.data.imports[fullPath].star = true;
+      }
+    },
+  },
+  aggregate(context, files) {
+    const map: Record<string, (typeof files)[number]["data"] | undefined> =
+      Object.fromEntries(files.map((file) => [file.data.path, file.data]));
+    for (const file of files) {
+      for (const path in file.data.imports) {
+        const data = map[path];
+        if (data) data.usages.push(file.data.imports[path]);
+      }
+    }
+    for (const file of files) {
+      if (file.data.exports.default) {
+        if (file.sourceFile.fileName.includes(".config.")) continue;
+        if (!file.data.usages.some((u) => u.default)) {
+          context.report({
+            message: messages.unusedDefaultExport,
+            sourceFile: file.sourceFile,
+            ...file.data.exports.default,
+          });
+        }
+      }
+      for (const named of file.data.exports.named) {
+        const used = file.data.usages.find(
+          (u) => u.star || u.named.includes(named.name),
+        );
+        if (!used) {
+          context.report({
+            message: messages.unusedNamedExport,
+            sourceFile: file.sourceFile,
+            node: named.node,
+          });
+        }
+      }
+    }
+  },
+}));

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,13 @@ export type Config = {
      */
     rules: Rule<any>[];
   }[];
+  /**
+   * The IDE implementation is still a work in progress,
+   * and memory leaks or performance issues may occur.
+   * @default false
+   * @experimental
+   */
+  enableProjectWideRulesInIDE?: boolean;
 };
 
 export type Rule<Data = undefined> = {
@@ -91,6 +98,20 @@ export type Rule<Data = undefined> = {
    * ```
    */
   visitor: AST.Visitor<Data>;
+  /**
+   * Called once after all files have been visited. Can be used to generate new reports that
+   * require cross-file analysis like validating imports or usages.
+   * @example
+   * ```ts
+   * aggregate: (context, files) => {
+   *
+   * }
+   * ```
+   */
+  aggregate?: (
+    context: AggregateContext,
+    files: { sourceFile: AST.SourceFile; data: Data }[],
+  ) => void;
 };
 
 export type Checker = Omit<
@@ -221,4 +242,26 @@ export type Context<Data = unknown> = {
    * Can be used to pass information between visited nodes.
    */
   data: Data;
+};
+
+export type ReportDescriptorWithSourceFile = ReportDescriptor & {
+  sourceFile: AST.SourceFile;
+};
+export type AggregateContext = {
+  program: Context["program"];
+  checker: Context["checker"];
+  compilerOptions: Context["compilerOptions"];
+  utils: Context["utils"];
+  /**
+   * Report a diagnostic
+   * @example
+   * ```ts
+   * context.report({
+   *   sourceFile: sourceFile,
+   *   node: node.expression,
+   *   message: "Foo is unused.",
+   * });
+   * ```
+   */
+  report(descriptor: ReportDescriptorWithSourceFile): void;
 };

--- a/tsl.config.ts
+++ b/tsl.config.ts
@@ -1,6 +1,7 @@
 import { core, defineConfig } from "./src/index.ts";
 
 export default defineConfig({
+  enableProjectWideRulesInIDE: true,
   rules: [
     ...core.all(),
     core.noConfusingVoidExpression({ ignoreArrowShorthand: true }),


### PR DESCRIPTION
Fixes #2

Rules can now implement an `aggregate` function that will be called once for all files that have been linted. This allows to implement rules that require cross-file analysis, like detecting circular dependencies.

```ts
import { type AST, core, defineConfig } from "tsl";

type ImportsData = {
  imports: { path: string; node: AST.ImportDeclaration }[];
};

export default defineConfig({
  rules: [
    ...core.all(),
    {
      name: "org/noCircularDependencies",
      createData: (): ImportsData => ({ imports: [] }),
      visitor: {
        ImportDeclaration(context, node) {
          context.data.imports.push({ path: toAbsolutePath(node), node });
        },
      },
      aggregate(context, files) {
        //                ^ { sourceFile: AST.SourceFile; data: ImportsData }[]
        for (const circularEntry of getCircularDependencies(files)) {
          context.report({
            message: "Circular dependency detected",
            sourceFile: circularEntry.sourceFile,
            node: circularEntry.data.imports[circularEntry.importIndex].node,
          });
        }
      },
    },
  ],
});
```

`enableProjectWideRulesInIDE` is an experimental new option to enable project-wide reports in the IDE (default to false). The IDE implementation is still a work in progress, and memory leaks or performance issues may occur.

`core/unusedExport` is a new project-wide rule available with this release.